### PR TITLE
Adding support for --token-usage/-t flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,4 +89,6 @@ poetry run codemage ./example/test.js ./example/sample.js -target c++
 
 -v, --version : Show program's version number and exit
 
+-t, --token-usage : Get information about token usage for the prompt and response
+
 

--- a/code_mage/codeMage.py
+++ b/code_mage/codeMage.py
@@ -18,7 +18,7 @@ def main():
     parser.add_argument('--language', '-l', help='The language to translate the source files into')
     parser.add_argument('--output', '-o', help="Specify the output file name(without extension)")
     parser.add_argument('--version', '-v', action='version', version=f'CodeMage {VERSION}', help="Show program's version number and exit")
-    parser.add_argument('--token-usage', '-t', action='store_true', help='Specify token usage for the prompt and response')
+    parser.add_argument('--token-usage', '-t', action='store_true', help='Get information about token usage for the prompt and response')
     
     args = parser.parse_args()
 

--- a/code_mage/translator.py
+++ b/code_mage/translator.py
@@ -80,3 +80,14 @@ def translate(source_file, args, num=""):
         
     with open(output_file, 'w') as f:
         f.write(result)
+
+
+    # prints token usage information if --token-usage/-t flag was provided
+    if token_flag:
+        prompt_tokens = completion.usage.prompt_tokens
+        completion_tokens = completion.usage.completion_tokens
+        total_tokens = completion.usage.total_tokens
+
+        print(f"Prompt tokens: {prompt_tokens}")
+        print(f"Completion tokens: {completion_tokens}")
+        print(f"Total tokens: {total_tokens}")

--- a/code_mage/translator.py
+++ b/code_mage/translator.py
@@ -1,4 +1,5 @@
 import os
+import sys
 from openai import OpenAI
 from dotenv import load_dotenv
 
@@ -89,9 +90,9 @@ def translate(source_file, args, num=""):
             completion_tokens = completion.usage.completion_tokens
             total_tokens = completion.usage.total_tokens
 
-            print(f"prompt tokens: {prompt_tokens}")
-            print(f"completion tokens: {completion_tokens}")
-            print(f"total tokens: {total_tokens}")
+            print(f"prompt tokens: {prompt_tokens}", file=sys.stderr)
+            print(f"completion tokens: {completion_tokens}", file=sys.stderr)
+            print(f"total tokens: {total_tokens}", file=sys.stderr)
         else:
-            print("Sorry, this model doesn't give token usage details")
+            print("Sorry, this model doesn't give token usage details", file=sys.stderr)
         

--- a/code_mage/translator.py
+++ b/code_mage/translator.py
@@ -84,10 +84,14 @@ def translate(source_file, args, num=""):
 
     # prints token usage information if --token-usage/-t flag was provided
     if token_flag:
-        prompt_tokens = completion.usage.prompt_tokens
-        completion_tokens = completion.usage.completion_tokens
-        total_tokens = completion.usage.total_tokens
+        if completion.usage.completion_tokens_details:
+            prompt_tokens = completion.usage.prompt_tokens
+            completion_tokens = completion.usage.completion_tokens
+            total_tokens = completion.usage.total_tokens
 
-        print(f"Prompt tokens: {prompt_tokens}")
-        print(f"Completion tokens: {completion_tokens}")
-        print(f"Total tokens: {total_tokens}")
+            print(f"prompt tokens: {prompt_tokens}")
+            print(f"completion tokens: {completion_tokens}")
+            print(f"total tokens: {total_tokens}")
+        else:
+            print("Sorry, this model doesn't give token usage details")
+        

--- a/code_mage/translator.py
+++ b/code_mage/translator.py
@@ -83,7 +83,7 @@ def translate(source_file, args, num=""):
         f.write(result)
 
 
-    # prints token usage information if --token-usage/-t flag was provided
+    # prints token usage information if --token-usage/-t flag is present
     if token_flag:
         if completion.usage.completion_tokens_details:
             prompt_tokens = completion.usage.prompt_tokens

--- a/code_mage/translator.py
+++ b/code_mage/translator.py
@@ -90,9 +90,9 @@ def translate(source_file, args, num=""):
             completion_tokens = completion.usage.completion_tokens
             total_tokens = completion.usage.total_tokens
 
-            print(f"prompt tokens: {prompt_tokens}", file=sys.stderr)
-            print(f"completion tokens: {completion_tokens}", file=sys.stderr)
-            print(f"total tokens: {total_tokens}", file=sys.stderr)
+            sys.stderr.write(f"prompt tokens: {prompt_tokens}\n")
+            sys.stderr.write(f"completion tokens: {completion_tokens}\n")
+            sys.stderr.write(f"total tokens: {total_tokens}\n")
         else:
-            print("Sorry, this model doesn't give token usage details", file=sys.stderr)
+            sys.stderr.write("Sorry, this model doesn't give token usage details\n")
         


### PR DESCRIPTION
## Fixes #7 

Thank you for making the process easier by adding the code for parsing the `--token-usage/-t ` option flag argument from the command line in `codeMage.py`!

## Implementation

I started implementing the feature by adding an if-statement that checks if the option flag was provided to `translator.py`. At first, if condition was met, my code was simply printing out the token information (that has been extracted from the `completion` object) to `stdout`,  however, after the first round of testing, I noticed that the token amounts are always equal to 0.

![image](https://github.com/user-attachments/assets/85724d34-8a17-47ea-b5f2-99acef23cc08)



After printing out the `completion` object, I've realized that completion token details are not being returned by the chosen model (`completion_token_details=None`).

![image](https://github.com/user-attachments/assets/efab0d4d-58df-4d22-9bc9-ca93038ee0fb)

That is why I added another check to see if completion token details are present in the response. Now, if details about the token usage are present, they get printed to `stderr`, else - the users will see a message saying that model didn't give any token usage details.

 
![image](https://github.com/user-attachments/assets/2d2ffe03-e947-4204-b21a-11ba7135b2fc)

## Examples

Running the command with a model that provides token usage details (openai/gpt-3.5-turbo)

![image](https://github.com/user-attachments/assets/5f3c2bfc-e7c5-40b5-82a5-19a7353a5895)

Running the command with a model that doesn't 

![image](https://github.com/user-attachments/assets/bb768537-3194-4ba7-b9c3-dcb9863aea32)

**To take advantage of the token usage feature, you can consider allowing users to specify the model of choice, or switching to a model that gives token usage details in its responses.**

## Changes

Apart from adding the code block with if-statements, I've imported `sys` at the top of `translator.py` for printing to `stderr`, added the info about the new option at the bottom of the README.md.
 
![image](https://github.com/user-attachments/assets/d8d1dc8a-9ebd-454c-8cbf-0fd4a3fc692a)

and updated the help info for flag option in `codeMage.py`

![image](https://github.com/user-attachments/assets/10042a84-0b9a-4276-b695-22274d27a458)
