### PR TITLE
Added a new test case in test_argsParser.py

### DIFF
--- a/tests/test_argsParser.py
+++ b/tests/test_argsParser.py
@@ -113,3 +113,12 @@ def test_arg_parser_token_usage_option_short(mock_config):
 	with patch("sys.argv", ["code_mage.py", "-t"]):
 		args = arg_parser(mock_config)
 		assert args.token_usage is True
+
+
+# Test invalid flag argument option
+def test_arg_parser_invalid_option():
+    with patch("sys.argv", ["code_mage.py", "--invalid"]):
+        with pytest.raises(SystemExit) as excinfo:
+            arg_parser({})
+        assert excinfo.type is SystemExit
+        assert excinfo.value.code != 0


### PR DESCRIPTION
Hello @gitdevjin , 

I added a new test case in `test_argsParser.py` to make sure that the argument parser terminates the program with a non-zero code when invoked with an invalid flag.

```python
# Test invalid flag argument option
def test_arg_parser_invalid_option():
    with patch("sys.argv", ["code_mage.py", "--invalid"]):
        with pytest.raises(SystemExit) as excinfo:
            arg_parser({})
        assert excinfo.type is SystemExit
        assert excinfo.value.code != 0
```